### PR TITLE
Acrescentado diretivas de complicacao em 3 units do middleware AWS4D

### DIFF
--- a/src/AWS4D.Interfaces.pas
+++ b/src/AWS4D.Interfaces.pas
@@ -4,7 +4,13 @@ interface
 
 uses
   System.Classes,
-  Jpeg,
+
+  {$IF CompilerVersion > 22}
+    Vcl.Imaging.jpeg,
+  {$ELSE}
+    jpeg,
+  {$IFEND}
+
   {$IFDEF HAS_FMX}
     FMX.Objects;
   {$ELSE}

--- a/src/AWS4D.S3.Get.pas
+++ b/src/AWS4D.S3.Get.pas
@@ -29,7 +29,11 @@ uses
   Data.Cloud.AmazonAPI,
   Data.Cloud.CloudAPI,
   System.SysUtils,
-  Jpeg;
+  {$IF CompilerVersion > 22}
+    Vcl.Imaging.jpeg;
+  {$ELSE}
+    jpeg;
+  {$IFEND}
 
 { TBind4DAmazonS3Get }
 

--- a/src/AWS4D.S3.pas
+++ b/src/AWS4D.S3.pas
@@ -1,9 +1,17 @@
 unit AWS4D.S3;
+
 interface
+
 uses
   System.Classes,
   AWS4D.Interfaces,
-  Jpeg,
+
+  {$IF CompilerVersion > 22}
+    Vcl.Imaging.jpeg,
+  {$ELSE}
+    jpeg,
+  {$IFEND}
+
   {$IFDEF HAS_FMX}
     FMX.Objects;
   {$ELSE}


### PR DESCRIPTION
As units AWS4D.Interfaces, AWS4D.S3, AWS4D.S3.Get do middleware AWS4D da erro quando você compila em versão do
DELPHI acima do XE8 ocorre um erro na "unit jpeg not found".

O trecho de código da "unit jpeg" na cláusula USES foi alterado para o trecho de código com as diretivas de compilação na VCL

  {$IF CompilerVersion > 22}
    Vcl.Imaging.jpeg,
  {$ELSE}
    jpeg,
  {$IFEND}
